### PR TITLE
Inherit Location and ActgClass from Base

### DIFF
--- a/lib/rubill/base.rb
+++ b/lib/rubill/base.rb
@@ -49,9 +49,10 @@ module Rubill
     end
 
     def self.find_by_name(name)
-      raw_result = Query.list(remote_class_name, 0, 1, [Query::Filter.new("name", "=", name)])
+      filter = Query::Filter.new("name", "=", name)
+      raw_result = Query.list(remote_class_name, 0, 1, [filter])
 
-      new(raw_result.first)
+      raw_result.length > 0 ? new(raw_result.first) : nil
     end
 
     def self.where(filters=[])

--- a/lib/rubill/entities/actg_class.rb
+++ b/lib/rubill/entities/actg_class.rb
@@ -1,3 +1,3 @@
 module Rubill
-  class ActgClass; end
+  class ActgClass < Base; end
 end

--- a/lib/rubill/entities/location.rb
+++ b/lib/rubill/entities/location.rb
@@ -1,3 +1,3 @@
 module Rubill
-  class Location; end
+  class Location < Base; end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -47,6 +47,33 @@ module Rubill
       end
     end
 
+    describe ".find_by_name" do
+      let(:filter_double) { double(Query::Filter) }
+
+      before(:each) do
+        allow(Query::Filter).to receive(:new).with("name", "=", anything).
+          and_return(filter_double)
+      end
+
+      it "finds an entity by name" do
+        result_double = double(Hash)
+
+        allow(Query).to receive(:list).with("Base", 0, 1, [ filter_double ]).
+          and_return([ result_double ])
+
+        expect(described_class).to receive(:new).with(result_double)
+
+        described_class.find_by_name("Name")
+      end
+
+      it "returns nil if entity not found" do
+        allow(Query).to receive(:list).with("Base", 0, 1, [ filter_double ]).
+          and_return([])
+
+        expect(described_class.find_by_name("Name")).to be_nil
+      end
+    end
+
     describe "#[]" do
       let(:remote) { {id: "123"} }
       subject { described_class.new(remote) }

--- a/spec/entities/actg_class_spec.rb
+++ b/spec/entities/actg_class_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+module Rubill
+  describe ActgClass do
+    it { expect(described_class).to be < Rubill::Base }
+  end
+end

--- a/spec/entities/attachment_spec.rb
+++ b/spec/entities/attachment_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 module Rubill
   describe Attachment do
+    it { expect(described_class).to be < Rubill::Base }
+
     let(:options) { { "a" => "b" } }
 
     describe ".send_attachment" do

--- a/spec/entities/location_spec.rb
+++ b/spec/entities/location_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+module Rubill
+  describe Location do
+    it { expect(described_class).to be < Rubill::Base }
+  end
+end


### PR DESCRIPTION
Hey @ataber,
I completely forgot to make Location and ActgClass inherit from Base in my latest PR, fixing that here. I've also added some specs for the logic I wrote previously.

Create spec for .find_by_name
Spec to ensure entities inherit from base